### PR TITLE
Add docker badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Travis badge](https://travis-ci.org/locdb/locdb-frend.svg?branch=master)](https://travis-ci.org/)
 [![Greenkeeper badge](https://badges.greenkeeper.io/locdb/locdb-frend.svg)](https://greenkeeper.io/)
+[![Docker Automated build](https://img.shields.io/docker/automated/locdb/locdb-frend.svg)](https://hub.docker.com/r/locdb/locdb-frend/)
 
 This repository provides a guided user interface for extrapolation of new data for the [Linked Open Citation Data Base](https://github.com/locdb/loc-db).
 More specific, two views are provided:


### PR DESCRIPTION
The docker image on https://hub.docker.com/r/locdb/locdb-frend/
will be now automatically re-built with every push on GitHub.