### PR TITLE
Rename "Reset" to "Cancel", remove misleading icon

### DIFF
--- a/src/app/resource-form/resource-form.component.html
+++ b/src/app/resource-form/resource-form.component.html
@@ -191,7 +191,7 @@
       <div class="row justify-content-between">
         <div class="col-xs-6 text-left">
           <button type="button" class="btn btn-warning" (click)="revert()" [disabled]="submitting">
-            <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span> Reset
+            <span class="glyphicon" aria-hidden="true"></span> Cancel
           </button>
           <button type="button" class="btn btn-danger" (click)="deleteResource()" [disabled]="submitting">
             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Delete

--- a/src/app/resource-form/resource-form.component.html
+++ b/src/app/resource-form/resource-form.component.html
@@ -190,11 +190,14 @@
       </div>
       <div class="row justify-content-between">
         <div class="col-xs-6 text-left">
-          <button type="button" class="btn btn-warning" (click)="revert()" [disabled]="submitting">
+          <button type="button" class="btn btn-warning" (click)="cancel()" [disabled]="submitting">
             <span class="glyphicon" aria-hidden="true"></span> Cancel
           </button>
+          <button type="button" class="btn btn-warning" (click)="revert()" [disabled]="submitting">
+            <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span> Reset Form
+          </button>
           <button type="button" class="btn btn-danger" (click)="deleteResource()" [disabled]="submitting">
-            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Delete
+            <span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Delete Resource
           </button>
         </div>
         <div class="col-xs-6 text-right">

--- a/src/app/resource-form/resource-form.component.ts
+++ b/src/app/resource-form/resource-form.component.ts
@@ -143,8 +143,6 @@ export class ResourceFormComponent implements OnInit, OnChanges  {
         // new clean set contribs
         this.setContributors(this.resource.contributors);
         this.setIdentifiers(this.resource.identifiers);
-        this.submitted = true;
-        this.submitting = false;
     }
 
     onSubmit() {
@@ -177,6 +175,11 @@ export class ResourceFormComponent implements OnInit, OnChanges  {
 
     revert() {
         this.ngOnChanges()
+    }
+
+
+    cancel() {
+        this.submitted = true; // effectively closes the form
     }
 
     reconstructAgentRole(name: string, role: string): AgentRole {


### PR DESCRIPTION
The button actually cancels the editing dialog so "Reset" is misleading